### PR TITLE
Remove language c from meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,5 @@
 project(
     'cffi-buildtool',
-    'c',
     version: '1.1.0',
 )
 


### PR DESCRIPTION
First off -- thank you for creating this tool. It was super useful as I tried to convert a project that made heavy use of a cffi build script through setuptools. 

I made a small change removing the `c` language specification in the `project(...)` in `meson.build`. I was packaging `cffi-buildtool` for conda-forge and was getting [errors](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1190413&view=logs&j=4cabe686-70ae-553a-7fd0-310379f2cbac&t=6a4fc7c9-c31a-5115-eff9-6479d72b69ff&l=757), because telling meson that this is a `c` project causes it to look for c-compilers, which isn't necessary for a pure python project like this (and the conda-forge build image doesn't include the c-compilers by default).  I patched it out in the conda-forge build and builds and installs the package [correctly](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1190415&view=logs&j=4cabe686-70ae-553a-7fd0-310379f2cbac&t=6a4fc7c9-c31a-5115-eff9-6479d72b69ff&l=888).

Thanks for considering this change.
